### PR TITLE
Remove the dependency on cssify

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,6 @@
     "develop": "can-serve --static --develop --port 8080"
   },
   "main": "dist/cjs/can-map-backup",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs"
   ],
@@ -64,7 +54,6 @@
   "devDependencies": {
     "can-map-define": "^3.0.0-pre.2",
     "can-ssr": "^0.11.6",
-    "cssify": "^0.6.0",
     "documentjs": "^0.4.2",
     "donejs-cli": "^0.7.0",
     "generator-donejs": "^0.7.0",


### PR DESCRIPTION
This removes the dependency on cssify, which is not used by this
package.